### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main_ukpinballleague-2020.yml
+++ b/.github/workflows/main_ukpinballleague-2020.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.31.1
+        uses: shivammathur/setup-php@2.33.0
         with:
           php-version: '7.3'
 
@@ -32,7 +32,7 @@ jobs:
         run: composer validate --no-check-publish && composer install --prefer-dist --no-progress
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: php-app
           path: .
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.2.1
         with:
           name: php-app
 

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.2.1](https://github.com/actions/download-artifact/releases/tag/v4.2.1)** on 2025-03-19T15:54:58Z
* **[shivammathur/setup-php](https://github.com/shivammathur/setup-php)** published a new release **[2.33.0](https://github.com/shivammathur/setup-php/releases/tag/2.33.0)** on 2025-04-15T08:26:15Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
